### PR TITLE
Add `iosX64` and `iosArm64` targets

### DIFF
--- a/src/main/kotlin/ru/mipt/npm/gradle/KScienceNativePlugin.kt
+++ b/src/main/kotlin/ru/mipt/npm/gradle/KScienceNativePlugin.kt
@@ -23,6 +23,8 @@ public class KScienceNativePlugin : Plugin<Project> {
                 linuxX64(),
                 mingwX64(),
                 macosX64(),
+                iosX64(),
+                iosArm64()
             )
 
             sourceSets {


### PR DESCRIPTION
Add `iosX64` and `iosArm64` targets to `nativeTargets`.
For more details see [issue #464](https://github.com/mipt-npm/kmath/issues/464)